### PR TITLE
ensure AB::MB is the configure requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ version = 0.006
 -remove = MakeMaker
 
 [Alien]
+:version = 0.023
 repo = file:inc
 pattern_prefix = leptonica-
 pattern_suffix = -min\.tar\.gz


### PR DESCRIPTION
This will ensure that AB::MB is specified as configure_requires